### PR TITLE
Variable Distance Shooting Formula Fix 

### DIFF
--- a/2026-2706-Robot-Code/src/main/java/frc/robot/subsystems/ShooterSubsystem.java
+++ b/2026-2706-Robot-Code/src/main/java/frc/robot/subsystems/ShooterSubsystem.java
@@ -103,8 +103,8 @@ public class ShooterSubsystem extends SubsystemBase {
         return 3250;
       case 2: // back wall
         return 3700;
-      case 3: // variable shooting using the photon distance with a quadratic regression formula (soft limit of 3250 RPM)
-        return Math.min((int) Math.round(5.4627 * Math.pow(m_PhotonSubsystem.getDistance(), 2) + 495.68047 * m_PhotonSubsystem.getDistance() + 2050), 3250); 
+      case 3: // variable shooting using the photon distance with the inverse of a quadratic regression formula from an rpm vs. distance graph (soft limit of 5000 RPM)
+        return Math.min((int) Math.round(Math.sqrt((m_PhotonSubsystem.getDistance() + 19.73755)/(5.13131*Math.pow(10, -8)))-17562.4743), 5000); 
       default:
         return 2650; // this is a fallback RPM, avg of other RPMs
     }


### PR DESCRIPTION
## Variable Distance Shooting Formula Fix

## Description
The original equation used the quadratic regression from a distance vs. rpm graph. However, it is an rpm vs. distance graph that has a  quadratic relation (distance increase quadratically as rpm increases linearly). The new formula takes the inverse of the quadratic regression from the rpm vs. distance graph, giving a square root relation between distance and rpm

## Further evidence of the original formula being off
- The quadratic was concave down -> indicates at some point you need less rpm to get more distance
- Online research says that displacement increases to the square of a projectile's initial velocity
- The square root relation never decreases -> indicates constant increase in rpm will constantly increase in distance

## Effect on robot
The difference in formula is fairly minimal in practice... Having the wrong formula felt unsatisfying.